### PR TITLE
[PollStream] remove unnecessary lifetime from ReadFut 

### DIFF
--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -485,7 +485,7 @@ enum ReadFut {
     /// Nothing in progress.
     Idle,
     /// Reading data from the underlying stream.
-    Reading(Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'static>>),
+    Reading(Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send>>),
     /// Finished reading, but there's unread data in the temporary buffer.
     RemainingData(Vec<u8>),
 }
@@ -496,9 +496,7 @@ impl ReadFut {
     /// # Panics
     ///
     /// Panics if `ReadFut` variant is not `Reading`.
-    fn get_reading_mut(
-        &mut self,
-    ) -> &mut Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'static>> {
+    fn get_reading_mut(&mut self) -> &mut Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send>> {
         match self {
             ReadFut::Reading(ref mut fut) => fut,
             _ => panic!("expected ReadFut to be Reading"),

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -481,16 +481,16 @@ impl Stream {
 const DEFAULT_READ_BUF_SIZE: usize = 4096;
 
 /// State of the read `Future` in [`PollStream`].
-enum ReadFut<'a> {
+enum ReadFut {
     /// Nothing in progress.
     Idle,
     /// Reading data from the underlying stream.
-    Reading(Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'a>>),
+    Reading(Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'static>>),
     /// Finished reading, but there's unread data in the temporary buffer.
     RemainingData(Vec<u8>),
 }
 
-impl<'a> ReadFut<'a> {
+impl ReadFut {
     /// Gets a mutable reference to the future stored inside `Reading(future)`.
     ///
     /// # Panics
@@ -498,7 +498,7 @@ impl<'a> ReadFut<'a> {
     /// Panics if `ReadFut` variant is not `Reading`.
     fn get_reading_mut(
         &mut self,
-    ) -> &mut Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'a>> {
+    ) -> &mut Pin<Box<dyn Future<Output = Result<Vec<u8>>> + Send + 'static>> {
         match self {
             ReadFut::Reading(ref mut fut) => fut,
             _ => panic!("expected ReadFut to be Reading"),
@@ -514,7 +514,7 @@ impl<'a> ReadFut<'a> {
 pub struct PollStream<'a> {
     stream: Arc<Stream>,
 
-    read_fut: ReadFut<'a>,
+    read_fut: ReadFut,
     write_fut: Option<Pin<Box<dyn Future<Output = Result<usize>> + Send + 'a>>>,
     shutdown_fut: Option<Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>>,
 
@@ -600,14 +600,10 @@ impl AsyncRead for PollStream<'_> {
                 let stream = self.stream.clone();
                 let mut temp_buf = vec![0; self.read_buf_cap];
                 self.read_fut = ReadFut::Reading(Box::pin(async move {
-                    let res = stream.read(temp_buf.as_mut_slice()).await;
-                    match res {
-                        Ok(n) => {
-                            temp_buf.truncate(n);
-                            Ok(temp_buf)
-                        }
-                        Err(e) => Err(e),
-                    }
+                    stream.read(temp_buf.as_mut_slice()).await.map(|n| {
+                        temp_buf.truncate(n);
+                        temp_buf
+                    })
                 }));
                 self.read_fut.get_reading_mut()
             }
@@ -724,14 +720,10 @@ impl AsyncWrite for PollStream<'_> {
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        let fut = match self.shutdown_fut.as_mut() {
-            Some(fut) => fut,
-            None => {
-                let stream = self.stream.clone();
-                self.shutdown_fut
-                    .get_or_insert(Box::pin(async move { stream.close().await }))
-            }
-        };
+        let stream = self.stream.clone();
+        let fut = self
+            .shutdown_fut
+            .get_or_insert_with(|| Box::pin(async move { stream.close().await }));
 
         match fut.as_mut().poll(cx) {
             Poll::Pending => Poll::Pending,


### PR DESCRIPTION
also, use get_or_insert_with instead of get_or_insert