### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
@@ -48,3 +48,22 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio-test = "0.4.2"
 lazy_static = "1.4.0"
 env_logger = "0.9.0"
 chrono = "0.4.19"
-clap = "2.34.0"
+clap = "3.2.6"
 
 [[example]]
 name = "ping"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ repository = "https://github.com/webrtc-rs/sctp"
 
 [dependencies]
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn"] }
-tokio = { version = "1.15.0", features = ["full"] }
-bytes = "1.1.0"
-rand = "0.8.4"
-crc = "2.1.0"
-async-trait = "0.1.52"
-log = "0.4.14"
-thiserror = "1.0.30"
+tokio = { version = "1.19", features = ["full"] }
+bytes = "1"
+rand = "0.8.5"
+crc = "3.0"
+async-trait = "0.1.56"
+log = "0.4"
+thiserror = "1.0"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio-test = "0.4.0"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 lazy_static = "1.4.0"
 env_logger = "0.9.0"
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = "0.4"
 thiserror = "1.0"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.0"
 lazy_static = "1.4.0"
 env_logger = "0.9.0"
 chrono = "0.4.19"


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version 
  (unless crates readme says otherwise)
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions 
  (unless crates readme says otherwise) OR specify major&minor 
  versions otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions