### PR TITLE
[PollStream] reset shutdown_fut future after done

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         toolchain:
-          - 1.56.1 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
+          - 1.57.0 # min supported version (https://github.com/webrtc-rs/webrtc/#toolchain)
           - stable
     runs-on: ${{ matrix.os }}
     steps:

--- a/src/stream/mod.rs
+++ b/src/stream/mod.rs
@@ -772,8 +772,14 @@ impl AsyncWrite for PollStream {
 
         match fut.as_mut().poll(cx) {
             Poll::Pending => Poll::Pending,
-            Poll::Ready(Err(e)) => Poll::Ready(Err(e.into())),
-            Poll::Ready(Ok(_)) => Poll::Ready(Ok(())),
+            Poll::Ready(Err(e)) => {
+                self.shutdown_fut = None;
+                Poll::Ready(Err(e.into()))
+            }
+            Poll::Ready(Ok(_)) => {
+                self.shutdown_fut = None;
+                Poll::Ready(Ok(()))
+            }
         }
     }
 }


### PR DESCRIPTION
fixes "async fn resumed after completion" panics, which occurs if you
call poll_shutdown after it has returned Poll::Ready once.